### PR TITLE
[nightshift] ci-fixes: remove unused Node.js from test job, add concurrency groups and timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,18 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     strategy:
       fail-fast: false
       matrix:
@@ -20,11 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8
@@ -47,6 +48,7 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: test
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
@@ -12,6 +16,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -50,6 +55,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: build
 
     steps:
@@ -68,6 +74,7 @@ jobs:
   publish-npm:
     if: vars.NPM_PUBLISH == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: build
 
     steps:
@@ -91,6 +98,7 @@ jobs:
   publish-pypi:
     if: vars.PYPI_PUBLISH == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: build
     environment:
       name: pypi


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** ci-fixes
**Category:** pr
**Repo:** Microck/traccia

## Changes

### ci.yml
- **Remove unused Node.js setup from test job** — the test job only runs Python lint/test, Node.js is only needed in the package job for npm smoke tests. This saves ~10-15s per matrix run (2 runs).
- **Add concurrency group** with  — prevents duplicate CI runs when pushing rapidly to the same branch.
- **Add timeout-minutes** — test job: 15min, package job: 10min. Prevents hung workflows from burning runner minutes indefinitely.

### release.yml
- **Add concurrency group** with  — prevents accidental double-publishing on race conditions while still grouping runs.
- **Add timeout-minutes** to all jobs — build: 15min, publish jobs: 5min each.

## Impact
- ~30s faster CI per push (removed Node.js setup × 2 matrix runs)
- Better resource management with concurrency control and timeouts
- No behavior changes to test execution or build output