### PR TITLE
chore: remove unused dead code

### DIFF
--- a/src/traccia/models.py
+++ b/src/traccia/models.py
@@ -133,11 +133,6 @@ class PersonSkillStatus(StrEnum):
     MANUAL = "manual"
 
 
-class ClaimOrigin(StrEnum):
-    OBSERVED = "observed"
-    INFERRED = "inferred"
-    MANUAL = "manual"
-
 
 class SignalClass(StrEnum):
     AMBIENT_INTEREST = "ambient_interest"
@@ -240,16 +235,6 @@ class PersonSkillState(TracciaModel):
     locked: bool = False
     manual_note: str | None = None
 
-
-class Claim(TracciaModel):
-    claim_id: str
-    claim_type: str
-    subject: str
-    predicate: str
-    object: str
-    evidence_ids: list[str] = Field(default_factory=list)
-    confidence: float = Field(ge=0.0, le=1.0)
-    origin: ClaimOrigin
 
 
 class ReviewItem(TracciaModel):

--- a/src/traccia/parsers.py
+++ b/src/traccia/parsers.py
@@ -100,11 +100,6 @@ TEXT_READ_ENCODINGS = (
 )
 
 
-@dataclass(slots=True)
-class SourceMaterial:
-    path: Path
-    relative_import_path: Path
-
 
 @dataclass(slots=True)
 class ParsedSourceContent:

--- a/src/traccia/taxonomy.py
+++ b/src/traccia/taxonomy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,10 +108,6 @@ SKILLS: tuple[SkillDefinition, ...] = (
 DOMAIN_BY_NAME = {domain.name: domain for domain in DOMAINS}
 SKILL_BY_NAME = {skill.name: skill for skill in SKILLS}
 
-
-@dataclass(slots=True)
-class MatchResult:
-    names: set[str] = field(default_factory=set)
 
 
 def match_skill_names(text: str) -> list[str]:


### PR DESCRIPTION
## Summary

Removes 3 unused classes and 1 unused enum discovered through dead code analysis.

### Removed
- **`Claim`** (models.py) - Pydantic model with zero references across src/ and tests/
- **`ClaimOrigin`** (models.py) - StrEnum only used by the removed Claim class
- **`SourceMaterial`** (parsers.py) - dataclass with zero references
- **`MatchResult`** (taxonomy.py) - dataclass with zero references

### Cleanup
- Removed unused `field` import from taxonomy.py

### Verification
- All files pass py_compile syntax check
- ruff check passes with zero violations
- 3 files changed, 1 insertion(+), 25 deletions(-)

---
*This PR was generated by [Nightshift](https://github.com/marcus/nightshift) - autonomous code quality bot.*