### PR TITLE
docs: add Traccia documentation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,557 +9,112 @@
 </p>
 
 <p align="center">
-<img width="800" height="auto" alt="export-screenshot2293_13-52-26-06-2026_squircle-micr-dev" src="https://github.com/user-attachments/assets/53d79097-98db-428a-8c6d-fe410abf5dff" />
+  <img width="800" height="auto" alt="traccia exported skill map" src="https://github.com/user-attachments/assets/53d79097-98db-428a-8c6d-fe410abf5dff" />
 </p>
 
----
+`traccia` turns personal archives into an evidence-backed skill graph.
 
-`traccia` turns personal archives into a skill graph that can explain itself. feed it notes, code, docs, AI chats, exported platform data, and the usual pile of half-structured personal history. it keeps the source files untouched, extracts evidence with timestamps, and renders a graph that shows where a skill came from, how deep it looks, how current it is, and how central it is to the broader archive.
+feed it notes, code, documents, exports, chats, and the usual pile of
+half-structured personal history. it keeps the source files untouched, extracts
+evidence one source at a time, and renders a graph that shows what skills
+appear, how strong the evidence is, how fresh the skill looks, and why the claim
+exists.
 
-the project is built for mixed archives rather than one clean source of truth. that includes repo history, google activity, social profiles, AI conversation logs, and everything else that tends to accumulate around a real person over time. the point is not to pretend those signals mean the same thing. `traccia` keeps weak signals weak, strong evidence strong, and the trail visible enough to challenge later.
+it is built for reflection, not resume scoring. weak signals stay weak, raw
+files stay private by default, and published views are generated through an
+explicit curation step.
 
-## why
+## quick start
 
-most archive tools are good at storing material and bad at telling the skill story. most profile tools do the opposite. they compress everything into a pitch, flatten uncertainty, and throw away the evidence trail that would let you inspect the claim later.
-
-`traccia` is trying to keep both sides intact. the files stay raw. the evidence is extracted one source at a time. the graph records when a skill first appeared, when it likely crossed from ambient interest into learned capability, and when there was strong enough proof to treat it as demonstrated work. that makes the output more useful for reflection, review, and long-range memory than a resume-shaped summary.
-
-## install
-
-`traccia` already ships a real console script. the Python package is still the canonical implementation, but the repo now also includes a thin npm wrapper for people who want to install or run the CLI from a Node-first environment without rewriting the tool in JavaScript.
-
-| path | command | result |
-| --- | --- | --- |
-| repo-local workflow | `uv sync` | keeps `uv run traccia ...` available inside the project |
-| bare `traccia` command with live local edits | `uv tool install -e .` | installs the console script on your `PATH` in editable mode |
-| standard editable install without `uv tool` | `pip install -e .` | installs the same console script through pip |
-| npm one-off wrapper | `npx @microck/traccia doctor .` | downloads the wrapper, then shells out to `uvx --from traccia traccia ...` |
-| npm global wrapper | `npm install -g @microck/traccia` | installs a `traccia` command on your `PATH`, backed by `uvx` |
-
-the unscoped npm package name `traccia` is already taken, so the wrapper is published as `@microck/traccia`. the installed command is still `traccia`.
-
-the wrapper does not embed Python. it still expects `uv` and `uvx` to exist on your machine, because its only job is to hand execution off to the real Python package cleanly.
-
-if you want the wrapper to pull the heavier document stack by default, set `TRACCIA_UVX_SPEC='traccia[document-markdown]'` before running it. if you are working inside this repo and want the wrapper to exercise the local checkout instead of PyPI, set `TRACCIA_USE_LOCAL_REPO=1`. that maintainer mode switches the wrapper from `uvx --from traccia traccia ...` to `uv run traccia ...` from the repo root.
-
-if you just want the shortest path from a clone, `uv tool install -e .` is still the cleanest direct install.
-
-document normalization providers are optional because some of them are heavy. the base install keeps the core CLI light, while the document stack can be added when you actually need high-quality local PDF and DOCX parsing:
-
-| extra | command | what it adds |
-| --- | --- | --- |
-| docling only | `uv sync --extra docling` | local markdown conversion plus local OCR backends such as tesseract, easyocr, and rapidocr |
-| marker only | `uv sync --extra marker` | stronger local PDF-to-markdown conversion, especially for layout-heavy PDFs |
-| full local document stack | `uv sync --extra document-markdown` | marker + docling + markitdown fallback chain |
-
-## first run
+install the Python CLI from a checkout:
 
 ```bash
+uv sync
 uv tool install -e .
+```
+
+create a project and ingest a folder:
+
+```bash
 traccia init my-traccia
+traccia doctor my-traccia
 traccia ingest-dir /path/to/archive --project-root my-traccia
 traccia tree --project-root my-traccia
 traccia explain python --project-root my-traccia
-traccia review --project-root my-traccia
-traccia export obsidian --project-root my-traccia
-traccia export debug-report --project-root my-traccia
 ```
 
-the finished-run skill map viewer has a three-step curation and publish workflow:
+export the results:
 
 ```bash
-# phase 1: generate the read-only public viewer from the current graph
+traccia export obsidian --project-root my-traccia
 traccia export viewer --project-root my-traccia
-
-# phase 2 admin: generate the admin curation viewer with the full graph
-# (includes hidden, disputed, review, and low-confidence nodes)
 traccia export admin --project-root my-traccia
-
-# after curating in the admin viewer (hide/mute, feature/pin, collapse domains,
-# add public label/note overrides, approve low-confidence or disputed nodes),
-# save curation.json into exports/viewer/, then publish:
-
-# phase 2 publish: generate the redacted public bundle from graph + curation
 traccia export publish --project-root my-traccia
 ```
 
-the admin viewer writes `curation.json` into `exports/viewer/curation.json` when
-served locally. when running from a static file server, the save action triggers
-a browser download of `curation.json` instead. the publish step reads that
-curation file and produces `exports/viewer-public/` with a separate public graph
-contract that physically excludes hidden nodes, hidden edges, raw provenance,
-raw excerpts, sensitive evidence IDs, disputed/review nodes (unless approved),
-and low-confidence nodes (unless approved). public node IDs remain the same as
-internal IDs unless a skill ID leaks private information, in which case stable
-`pub_<hash>` aliases are generated with the mapping kept admin-only.
+## what it produces
 
-if a long graph scoring run is already active and you want to prepare more files without
-starting a second LLM lane, use staged ingest:
-
-```bash
-traccia stage-dir /path/to/archive --project-root my-traccia
-```
-
-`stage-dir` discovers materials, detects source families, links raw files into
-`raw/imported/`, parses spans, and writes resumable progress. it deliberately does not
-call the LLM extractor, does not recompute the graph, and does not run deletion sync.
-prepared materials are marked as `prepared`, so a later normal `traccia ingest-dir` can
-extract evidence and sync the graph from that checkpoint.
-
-if you want full evidence extraction while a separate graph scorer is already running,
-run normal ingest with graph and deletion sync disabled:
-
-```bash
-traccia ingest-dir /path/to/archive --project-root my-traccia --no-sync-graph --no-sync-deletions
-```
-
-live LLM calls are coordinated through an advisory lease at
-`TRACCIA_LLM_LEASE_PATH` or `/tmp/traccia-llm-request.lock` by default. graph
-canonicalization and serial scoring use the lease exclusively. evidence extraction
-and parallel skill scoring use shared lease slots only when you explicitly raise
-their worker counts. the active scorer owns graph table writes; newly extracted
-evidence is stored in SQLite and will be included in the next graph scoring pass.
-
-graph scoring has two modes:
-
-| mode | command | use it for |
-| --- | --- | --- |
-| incremental | `traccia score --mode incremental --project-root my-traccia` | normal operation; reuses unchanged candidate and skill score caches |
-| full | `traccia score --mode full --project-root my-traccia` | repair, audit, or model/prompt changes where every graph decision should be rerun |
-
-Skill scoring can also run with a bounded internal worker pool:
-
-```bash
-traccia score --mode incremental --project-root my-traccia --parallel-scores 4
-```
-
-The same default can live in config:
-
-```yaml
-graph_scoring:
-  parallel_scores: 4
-```
-
-Only final skill scoring is parallelized. Candidate canonicalization, cache writes,
-progress writes, graph checkpoints, and final rendering stay parent-side serialized.
-Each worker receives the same per-skill prompt payload it would receive in a serial
-run, so the final skill states should match one-worker scoring when the same model
-and deterministic backend behavior are used. Use a value that matches available
-provider quota; higher values spend quota faster but do not improve per-skill
-reasoning quality.
-
-normal `ingest` and `ingest-dir` runs use incremental scoring by default. pass
-`--score-mode full` to force a full scoring pass after ingest, or
-`--score-mode none` to extract evidence without touching graph projections.
-scoring progress is written to `state/graph-score-progress.json`; ingest progress
-continues to live in `state/progress.json`.
-
-scoring also writes run telemetry for later analysis. `state/graph-score-runs.jsonl`
-is an append-only event stream with run IDs, model, score mode, cache hit/miss
-counts, candidate progress, and final totals. `state/catalog.sqlite` also stores
-one summary row per scoring run in `pipeline_runs`. These artifacts avoid raw
-source excerpts and omit candidate/skill display names from the JSONL stream.
-
-if you want one ingest process to extract multiple independent materials at once,
-set `ingest.parallel_extractions` in `config/config.yaml` or pass
-`--parallel-extractions N` to `ingest-dir`:
-
-```bash
-traccia ingest-dir /path/to/archive --project-root my-traccia --parallel-extractions 4
-```
-
-the default is `1`. higher values only parallelize evidence extraction for separate
-materials. resume checks, manifests, progress writes, deletion sync, and live graph
-checkpoints stay parent-side serialized. final graph scoring can separately use
-`graph_scoring.parallel_scores`, and it still recomputes from durable per-source
-evidence rather than from compressed batches.
-
-for a split lane pool, configure `backend.extraction_backends` instead of only
-raising `ingest.parallel_extractions`. the lane pool decides which OpenAI-style
-backend handles extraction, while the primary backend still handles canonicalization
-and scoring:
-
-```yaml
-backend:
-  provider: openai_compatible
-  model: glm-5-turbo
-  api_key_env: CLIPROXYAPI_KEY
-  base_url: http://127.0.0.1:8317/v1
-  api_style: chat_completions
-  structured_output_mode: json_schema
-  supports_vision: false
-  extraction_backends:
-    - name: glm
-      model: glm-5-turbo
-      api_key_env: CLIPROXYAPI_KEY
-      base_url: http://127.0.0.1:8317/v1
-      parallel_extractions: 5
-    - name: gemini
-      model: star-gemini-3.5-flash
-      api_key_env: CLIPROXYAPI_KEY
-      base_url: http://127.0.0.1:8317/v1
-      supports_vision: true
-      parallel_extractions: 3
-```
-
-in that layout, extraction workers are split 5/3 across glm and gemini, but graph
-canonicalization and scoring still stay on the primary backend model.
-
-when targeting a subfolder from a larger mounted archive, pass `--import-prefix` to
-keep stable source IDs. this avoids duplicating a folder that was originally ingested
-from a higher root, and it prevents two different accounts with the same folder name
-from colliding:
-
-```bash
-traccia ingest-dir /mnt/gdrive2/rrss-data/08042026/Twitter \
-  --project-root my-traccia \
-  --import-prefix rrss-data/08042026/Twitter \
-  --no-sync-graph \
-  --no-sync-deletions
-```
-
-During discovery, `state/progress.json` separates `seen_this_scan` from
-`already_tracked` and `new_to_run_state`. The scan count is just the number of
-materials seen while walking the folder; `new_to_run_state` is the useful number when
-you want to know what was not part of the previous resumable run.
-
-for deterministic local testing, switch the generated config to:
-
-```yaml
-backend:
-  provider: fake
-```
-
-for a live model, the current backend contract is an openai-style `v1/chat/completions` endpoint:
-
-```yaml
-backend:
-  provider: openai_compatible
-  model: gpt-5-chat-latest
-  api_key_env: OPENAI_API_KEY
-  base_url: https://api.openai.com/v1
-  api_style: chat_completions
-  structured_output_mode: json_schema
-```
-
-any provider that clones the same request and response shape can be used by swapping `base_url`, `model`, and `api_key_env`. the current implementation deliberately targets `chat_completions` because it remains the most commonly copied interface across hosted and self-hosted providers, even if some vendors now prefer newer APIs for their own stacks.
-
-## backend surface
-
-| key | example | meaning |
-| --- | --- | --- |
-| `provider` | `openai_compatible` | live LLM backend that speaks an OpenAI-style HTTP contract |
-| `model` | `gpt-5-chat-latest` | current chat-capable example model id; replace it with any compatible model your provider exposes |
-| `api_key_env` | `OPENAI_API_KEY` | environment variable that holds the credential |
-| `base_url` | `https://api.openai.com/v1` | root URL for the compatible endpoint |
-| `api_style` | `chat_completions` | the only live API style supported right now |
-| `structured_output_mode` | `json_schema` | primary structured-output mode; `json_object` is also supported |
-| `supports_vision` | `false` | whether this backend should be trusted to accept multimodal image parts on the OpenAI-style endpoint |
-| `vision_detail` | `auto` | image detail hint passed to multimodal-capable backends when raw images are sent |
-
-## linked media and vision
-
-`traccia` now treats linked media as part of the same source context instead of as a detached second source. if a tweet, post, message, or export record references local media, the parent source can carry that attachment context into evidence extraction.
-
-there are two separate layers here:
-
-| layer | default | what it does |
-| --- | --- | --- |
-| linked attachments | on | discovers media references, resolves local files when possible, and attaches labels plus local OCR text to the parent source context |
-| remote media enrichment | on | detects eligible remote media URLs in source text and tries to recover transcript plus visual tutorial context with `summarize --extract`, mainly for youtube and direct audio or video links |
-| raw vision to the LLM | off | sends the actual image bytes to the backend only when you explicitly enable vision and mark the backend as vision-capable |
-
-that split is deliberate. OpenAI-style endpoint compatibility does not guarantee that a model or proxy really supports multimodal image input. `traccia` therefore keeps the context-preserving attachment path on by default, while the raw image lane stays opt-in.
-
-the remote URL lane is deliberately narrower than "summarize every link". for now it only targets media-shaped URLs where transcript and visual-context recovery materially improve evidence quality without replacing the original source record. a youtube watch URL inside a google activity export is a good example. a random article URL is not.
-
-the config looks like this:
-
-```yaml
-backend:
-  supports_vision: false
-  vision_detail: auto
-
-multimodal:
-  enable_linked_attachments: true
-  enable_vision: false
-  enable_local_image_ocr: true
-  enable_local_media_transcription: true
-  enable_remote_media_enrichment: true
-  audio_transcription_provider: auto
-  audio_transcription_model: turbo
-  audio_transcription_device: cpu
-  remote_media_enrichment_command: summarize
-  remote_media_enrichment_video_mode: understand
-  enable_remote_media_slides: true
-  enable_remote_media_slides_ocr: true
-  max_attachments_per_source: 4
-  max_attachment_text_characters: 1200
-  max_attachment_transcript_characters: 8000
-  max_image_bytes: 5000000
-  ocr_timeout_seconds: 20
-  transcription_timeout_seconds: 1800
-  remote_media_enrichment_timeout_seconds: 180
-```
-
-in practice, `enable_linked_attachments: true` should stay on unless you explicitly want text-only parsing. `enable_vision: true` should only be enabled when the chosen backend model and proxy actually accept image inputs, and `backend.supports_vision: true` should only be marked on for those known-good multimodal endpoints.
-
-when a material has resolved local image attachments and the active backend is not vision-capable, `traccia` now delays that material instead of extracting it with a text-only model. delayed entries are written to the manifest and resumable run-state as `status: delayed`; rerunning the same project with a vision backend such as `star-gemini-3-flash` processes those entries from the same source context. this keeps a tweet/post/message and its images together without letting a non-vision model silently miss the image content.
-
-`enable_local_image_ocr: true` keeps free local attachment text extraction available even with vision disabled. `enable_local_media_transcription: true` keeps local transcripts available for attached audio and video files. `audio_transcription_provider: auto` currently means "use local `whisper` when it exists, otherwise skip transcription cleanly", and `ffmpeg` is still the local preprocessing step that strips or normalizes audio before transcription.
-
-`enable_remote_media_enrichment: true` enables the `summarize` lane for remote media URLs that are found inline in the source text. the default command is `summarize`, but `remote_media_enrichment_command` can point at another binary path if you keep it somewhere custom. disabling that flag leaves the original URLs in the source text but stops the extra remote enrichment pass.
-
-the remote media default is intentionally high-context: `remote_media_enrichment_video_mode: understand`, `enable_remote_media_slides: true`, and `enable_remote_media_slides_ocr: true`. for youtube, that asks `summarize` to combine transcript extraction with slide/screenshot extraction and OCR. this is useful for watch history, comments, playlists, activity records, visual tutorials, CAD/Blender/code walkthroughs, diagrams, and lecture slides where the video title alone is weak.
-
-that default is a real media toolchain, not just a single python dependency. install `summarize`, `ffmpeg`, `yt-dlp`, and `tesseract` for the full `understand + slides + OCR` lane. when captions are not available and `summarize` must fall back to audio transcription, it also needs either a supported transcription API key (`GROQ_API_KEY`, `ASSEMBLYAI_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `FAL_KEY`) or a local whisper.cpp setup visible to `summarize`. local whisper.cpp means both a `whisper-cli` binary, or `SUMMARIZE_WHISPER_CPP_BINARY`, and a model file. `summarize` defaults to `~/.summarize/cache/whisper-cpp/models/ggml-base.bin`; override it with `SUMMARIZE_WHISPER_CPP_MODEL_PATH`. run `traccia doctor` to see whether remote media enrichment is `ready`, `degraded`, or `disabled`, including the exact whisper.cpp model path being checked.
-
-if you want the faster lane, set `remote_media_enrichment_video_mode: transcript` and turn both slide flags off. if you want no remote lookups, set `enable_remote_media_enrichment: false`.
-
-with that setup, a post plus its screenshot, photo, chart, or attached image can be analyzed together without forcing every backend into a vision-only contract.
-
-audio and video attachments now follow the same principle. if a source references a local clip, `traccia` can extract a local transcript and attach it back to the parent source context instead of treating the clip as a detached second-class file. that keeps the text post, the media metadata, and the recovered speech in one extraction bundle. if the source instead carries a remote youtube or direct media URL, `traccia` can now recover transcript plus visual context through `summarize --extract` and keep that alongside the original source event instead of flattening the whole thing into an ungrounded summary.
-
-## google takeout
-
-Google Takeout archives are not treated as a flat pile of files. `traccia` applies a product-aware relevance policy before parsing so the run spends model quota on skill-bearing material and skips account metadata, empty exports, raw binaries, caches, indexes, and bulk runtime/game data.
-
-The default policy is:
-
-| product | default behavior | why |
-| --- | --- | --- |
-| Gmail / `Correo` | keep headers and labels for all messages, include body snippets only for sent mail | received mail often describes other people or newsletters; sent mail is stronger self-authored evidence |
-| YouTube / YouTube Music | keep history, comments, subscriptions, metadata, and URLs; skip raw uploaded video binaries | titles, comments, watch history, and transcripts are usually higher-value than uploading large media blobs |
-| Google Photos / `Google Fotos` | sample a small number of images per folder and pair each image with its sidecar JSON | photos can be useful, but full photo libraries are expensive and repetitive |
-| Drive | keep selective document/code/data formats; skip archives, game/runtime data, large media, and unsupported binaries | Drive mixes authored work with bulk backups, dependencies, and opaque media |
-| account/payment/device products | skip by default | these exports are usually identity or settings metadata, not skill evidence |
-
-Google Photos sidecar JSON files are not ingested as standalone evidence. They are paired with sampled image materials so a vision-capable backend sees the image and the metadata in the same source context. If the configured backend cannot process vision input, those image materials are marked `delayed` and can be resumed later with a vision backend instead of being silently degraded to text-only extraction.
-
-YouTube URLs found in Takeout records use the same remote media enrichment lane described above by default. If `summarize` can recover a transcript, slide OCR, or useful extract, that text stays attached to the original Takeout record. Deleted, private, or unavailable videos fall back to the original title, URL, timestamp, and surrounding activity record.
-
-The relevant config block is:
-
-```yaml
-google_takeout:
-  relevance_mode: skill_relevant
-  gmail_mode: metadata_plus_sent
-  youtube_enrichment: detailed
-  photos_mode: fast_vision
-  drive_mode: selective_docs
-  max_photo_vision_samples_per_folder: 8
-```
-
-Set `max_photo_vision_samples_per_folder: 0` if you want to skip Google Photos images entirely. Keep it small for huge Takeout archives unless you are intentionally spending vision quota on photo analysis.
-
-Supported mode values are intentionally simple right now:
-
-| key | useful values |
+| output | purpose |
 | --- | --- |
-| `relevance_mode` | `skill_relevant` or `off` |
-| `gmail_mode` | `metadata_plus_sent` or `off` |
-| `photos_mode` | `fast_vision` or `off` |
-| `drive_mode` | `selective_docs`, `all`, or `off` |
+| `graph/graph.json` | Machine-readable skill graph. |
+| `tree/index.md` | Markdown overview of the graph. |
+| `tree/nodes/*.md` | One markdown page per skill. |
+| `profile/skill.md` | A profile summary derived from accepted graph state. |
+| `exports/obsidian/` | Obsidian-friendly vault export. |
+| `exports/viewer/` | Public read-only skill map viewer. |
+| `exports/viewer-admin/` | Admin curation viewer. |
+| `exports/viewer-public/` | Redacted public bundle generated from curation. |
 
-## document normalization
+## install paths
 
-`traccia` now treats document normalization and OCR as separate concerns. that split is deliberate. converting a file into clean markdown is one problem. deciding how to recover text from scanned pages or embedded images is another.
+the canonical implementation is the Python package. the npm package is a thin
+launcher for Node-first environments.
 
-the default path is local-first and format-aware:
-
-| input | default `auto` chain | why |
+| path | command | notes |
 | --- | --- | --- |
-| pdf | `marker -> docling -> markitdown -> native` | marker is the strongest local PDF path here for layout-heavy markdown output, docling is the strongest local OCR-capable fallback, markitdown is a lighter markdown fallback, native is last-resort plain text |
-| docx | `docling -> markitdown -> native` | docling is the better structured local default for office documents, while markitdown remains a useful markdown fallback |
+| repo-local | `uv sync` then `uv run traccia ...` | best while developing. |
+| editable CLI | `uv tool install -e .` | installs `traccia` on `PATH`. |
+| pip editable | `pip install -e .` | same console script through pip. |
+| npm one-off | `npx @microck/traccia doctor .` | requires `uvx` on `PATH`. |
+| npm global | `npm install -g @microck/traccia` | installs the npm launcher. |
 
-the providers do different jobs:
-
-| provider | what it is for | tradeoff |
-| --- | --- | --- |
-| `auto` | best default, local-first fallback chain | behavior depends on installed optional tools |
-| `marker` | strongest wired local PDF markdown path | heavier dependency, currently wired for PDF only in `traccia` |
-| `docling` | best all-around local document parser with local OCR backends | larger install than the base package |
-| `markitdown` | lightweight markdown-oriented fallback | weaker on difficult scanned/layout-heavy documents |
-| `native` | plain text extraction only | lowest fidelity, but minimal dependencies |
-
-OCR is configured separately:
-
-| `ocr_provider` | effect |
-| --- | --- |
-| `auto` | use the provider's local automatic OCR path; for docling this means local OCR engine auto-detection |
-| `none` | disable OCR entirely and only use extractable document text |
-| `tesseract` / `tesseract_cli` / `easyocr` / `rapidocr` | force a specific local docling OCR backend |
-
-that means OCR is no longer tied to OpenAI or any hosted vision API. if you want the whole stack local and free, keep the backend fake or point the scoring backend somewhere else entirely. the document parser does not need OpenAI for OCR anymore.
-
-### enable or disable it
-
-the default config is already:
-
-```yaml
-document_normalization:
-  provider: auto
-  ocr_provider: auto
-```
-
-force the strongest wired local PDF path:
-
-```yaml
-document_normalization:
-  provider: marker
-  ocr_provider: auto
-```
-
-disable marker and keep everything in the docling lane:
-
-```yaml
-document_normalization:
-  provider: docling
-  ocr_provider: auto
-```
-
-disable OCR completely:
-
-```yaml
-document_normalization:
-  provider: auto
-  ocr_provider: none
-```
-
-fall all the way back to plain-text extraction:
-
-```yaml
-document_normalization:
-  provider: native
-  ocr_provider: none
-```
-
-the practical difference is simple. if your PDFs are born-digital and layout-heavy, `marker` is usually the best local first try. if your documents are scanned, mixed, multilingual, or need a specific free OCR engine, `docling` is the more controllable path. `markitdown` stays useful as a lighter markdown fallback, not as the main OCR system.
-
-## doctor
-
-`traccia doctor` now checks more than the scaffold. it also prints the optional local capability surface so you can see what the current machine can actually do before launching a multi-hour ingest.
-
-it reports document normalization availability for `docling`, `markitdown`, and `marker_single`, local image OCR availability through `tesseract`, local media transcription availability through `ffmpeg`, `ffprobe`, and `whisper`, remote media enrichment availability through `summarize`, and backend auth plus optional backend health when `--check-backend` is used.
-
-that split matters in practice. a project can be structurally healthy while still missing the local tools needed for OCR or transcription, and `doctor` now makes that visible up front.
-
-## what it does today
-
-the current build already handles immutable source intake into `raw/imported/`, file-by-file parsing with span tracking, source classification across authored material and activity traces, and evidence extraction that tries to separate real work from ambient interest. known export families no longer go straight through the same raw path either. google takeout html, csv, json, calendar `.ics`, and gmail `.mbox` exports now get normalized into cleaner record-oriented text before the model sees them, while twitter `window.YTD` javascript payloads and reddit csv bundles also pass through family-aware adapters instead of the raw fallback lane.
-
-that normalization layer also now discovers linked media attachments generically. when a supported export references local media, the parent source can carry attachment metadata, local OCR text, and optional raw image input into the same extraction request instead of losing the relationship between the text and the media. when the source text itself includes eligible remote media URLs, the same attachment lane can now recover transcript-like text through `summarize` without replacing the original export record.
-
-for google takeout specifically, the parser is no longer limited to a generic text wrapper. youtube subscription, comment, and video metadata csvs are now turned into cleaner row-oriented records, broad google json exports such as profile and chrome history are summarized into structured blocks, calendar `.ics` exports become event records, and gmail `.mbox` dumps are compacted into per-message blocks with headers plus body snippets. that is still not the same thing as a perfect first-party schema adapter for every google product, but it is materially better than treating the whole export as opaque text.
-
-the ingest side also writes manifests and live progress state with family and subproduct counts. that means a long-running scan can be inspected as "twitter archive direct-messages" or "instagram export messages" instead of just "generic text files", and discovery works without requiring backend auth so you can classify an archive before spending any model quota.
-
-directory ingests now also keep a persistent run-state file under `state/ingest-runs/`. if a long scan stops because the backend hits quota or cooldown, the next `ingest-dir` run can fast-resume already completed materials instead of re-parsing and re-extracting them from zero. the immutable manifest snapshots in `state/manifests/` still record what each individual run did, while the resumable state is the mutable operator-facing checkpoint.
-
-if you temporarily run different backend/model lanes in separate project roots, merge the completed source evidence back into the canonical project instead of comparing two final skill tables by hand:
+optional document parsing extras are available when you need heavier local PDF
+or DOCX normalization:
 
 ```bash
-traccia merge-project /path/to/other-traccia-project --project-root /path/to/canonical-project
+uv sync --extra docling
+uv sync --extra marker
+uv sync --extra document-markdown
 ```
 
-`merge-project` imports source, span, and evidence records, then rebuilds the target graph by default. it intentionally does not import the other project's final skill rows or extraction checkpoints, because skills are derived from evidence and checkpoints are only safe inside the exact run that created them. use `--no-rebuild` when the target project is actively ingesting and should pick up the imported evidence at its next normal graph refresh.
+## documentation
 
-long directory runs still checkpoint raw ingest state after each material, but live graph refreshes are disabled by default. that keeps crash recovery file-granular while spending model quota on extracting new evidence instead of repeatedly rescoring nearly identical intermediate graphs. tune this under `graph_refresh` in `config.yaml` if you want opt-in live checkpoints; the default is final-only graph sync. parsed files that produce no evidence still resume correctly, and final output semantics are unchanged because the final graph is derived from the stored evidence table.
+start here:
 
-the batch is not a summarization boundary. each material is still parsed independently, materials are kept whole when they fit the extraction budget, oversized materials are extracted chunk by chunk, and every accepted evidence item is stored separately in SQLite with its source, span, quote, candidate skills, confidence, and timestamps. agent-log parsed artifacts keep assistant, tool, system, and thinking spans for audit, but extraction only receives user/human/developer spans so model output is not re-attributed as user skill. graph recompute then loads the stored evidence table and compares candidate skills against the existing catalog. that means delayed graph refreshes should not lose per-file or per-chunk information; they only delay when the rendered graph catches up.
+- [Documentation index](docs/index.md)
+- [Quickstart](docs/quickstart.md)
+- [CLI reference](docs/cli-reference.md)
+- [Project layout](docs/project-layout.md)
+- [Ingestion guide](docs/ingestion.md)
+- [Configuration reference](docs/configuration.md)
+- [Exports and publishing](docs/exports.md)
+- [Architecture overview](docs/architecture.md)
+- [Codebase map](docs/codebase-map.md)
+- [Repository inventory](docs/repository-inventory.md)
+- [Development guide](docs/development.md)
 
-each render also now writes a post-run debug bundle under `exports/debug/`. `report.json` is the machine-readable artifact, while `report.md` is the human-readable summary. they include source counts, parser and family breakdowns, attachment counts, evidence distributions, top skills, and pointers to the latest ingest progress, manifest, and resumable run-state files. if you want to regenerate that after review actions or a manual graph rebuild, run `traccia export debug-report`.
+design records and deeper planning notes remain in `docs/` for maintainers.
 
-the rendering side produces markdown node pages, profile exports, `graph.json`, `tree.json`, an ascii tree, and an obsidian vault export with actual note generation instead of a dead folder dump.
+## core guarantees
 
-## input surface
+- Source files in `raw/` are not rewritten by the LLM.
+- First-pass extraction is scoped to one source or source chunk.
+- Evidence is stored before graph scoring.
+- SQLite is the canonical derived state.
+- Markdown, JSON, profile files, and viewers are projections.
+- Public publishing physically removes hidden/private graph data from the public
+  bundle.
 
-`traccia` is aimed at mixed personal archives, not just project repos. the current input shape looks like this:
-
-| source class | examples | current treatment |
-| --- | --- | --- |
-| authored material | markdown, plain text, docs, notes, READMEs | parsed directly and cited back with spans where possible |
-| code and technical artifacts | python, js, ts, tsx, rust, go, sql | treated as stronger evidence when they show actual implementation work |
-| structured exports | json, csv, pdf, docx | parsed into document records and evidence candidates, with local markdown normalization for documents when optional providers are installed |
-| activity exports | AI conversation JSON, reddit JSON, google activity JSON | normalized into a common structure before evidence extraction |
-| broader archive direction | social profiles, issue trackers, twitter or x exports, more takeout-style dumps | explicitly in scope for future expansion, but not all implemented yet |
-
-the intended archive boundary is wider than the current parser list. the system is meant to grow toward bigger archive imports without treating every interaction as equal proof of competence.
-
-in practice the ingest model is hybrid. major export families get explicit adapters where the raw provider format is especially bad for downstream extraction, and everything else still gets ingested one file at a time through the generic parser path. that keeps the pipeline open-ended without pretending every export structure deserves identical handling.
-
-## output surface
-
-after ingest, `traccia` renders a graph plus several practical projections around it:
-
-| artifact | purpose |
-| --- | --- |
-| `tree/index.md` | top-level skill tree snapshot |
-| `tree/nodes/*.md` | per-skill pages with evidence, timestamps, related skills, and reasoning |
-| `tree/log.md` | render log and longitudinal notes |
-| `graph/graph.json` | full graph export for tooling, including per-node evidence provenance |
-| `graph/tree.json` | simplified tree projection |
-| `profile/skill.md` | profile-style summary built from the graph |
-| `exports/obsidian/` | obsidian-friendly note graph export |
-
-each skill node is meant to answer the questions that normal profile tools dodge. where does this skill fit. what evidence supports it. which source file did that evidence come from. how deep does the work look. how current is it. when did it first show up. when does it look learned rather than merely noticed. when was there strong enough evidence to trust it. how tightly does it connect back into the rest of the self-model.
-
-`graph/graph.json` carries this as a compact `provenance` array on each node. by default it keeps full source paths redacted, but still exposes source IDs, filenames, parser/source-family metadata, evidence IDs, timestamps, evidence types, confidence, and redacted excerpts. set `privacy.redact_source_paths_in_exports: false` if you want exported graph nodes to include `uri` and `relativeImportPath` as well.
-
-## scoring stance
-
-`traccia` keeps current mastery and core-self centrality separate on purpose. those are related, but they are not the same thing. a skill can be central because it keeps showing up across the archive while still being shallow. another skill can be deep but narrow because it only appears in one intense period of work.
-
-that separation matters once you ingest noisy exports. searches, follows, bios, bookmarks, lightweight chats, and stray mentions can support interest, context, or identity. on their own they should not inflate mastery. the system is designed to preserve those lighter signals without letting them pretend to be authored work or repeat implementation evidence.
-
-## command surface
-
-the full command list lives behind `traccia --help`, but the current working surface is already broad enough to use day to day:
-
-| command | use |
-| --- | --- |
-| `traccia init` | scaffold a new project |
-| `traccia doctor` | verify the scaffold and backend config |
-| `traccia discover-dir` | classify a directory before ingest and show family/subproduct counts |
-| `traccia ingest` / `traccia ingest-dir` | import files into the graph pipeline |
-| `traccia score` | update graph scoring with `incremental` or `full` mode |
-| `traccia merge-project` | merge source/evidence records from another project into one canonical graph |
-| `traccia rebuild` | recompute the graph from stored material |
-| `traccia tree` | print the current tree |
-| `traccia explain` / `traccia why` | inspect one skill node |
-| `traccia evidence` | list evidence connected to a skill |
-| `traccia review` | process uncertain graph changes |
-| `traccia alias` | manage canonical aliases |
-| `traccia export ...` | write graph, profile, markdown, and obsidian projections |
-
-## repo map
-
-| path | purpose |
-| --- | --- |
-| `docs/spec.md` | product and architecture spec |
-| `docs/plan.md` | implementation plan and phase boundaries |
-| `docs/decisions.md` | decisions and research conclusions |
-| `docs/ingest-architecture.md` | source-family ingest, checkpoint, and graph-refresh contract |
-| `docs/architecture-notes.md` | scoring, persistence, and high-risk module notes |
-| `docs/references.md` | inspirations and anti-references |
-| `src/traccia/` | implementation |
-| `tests/` | fixtures and regression coverage |
-
-## verification
-
-the current repo verification path is:
-
-```bash
-uv run ruff check src tests
-uv run pytest -q
-uv build
-```
-
-the live external backend path still depends on real credentials and a reachable compatible endpoint. nothing in this README assumes OpenAI specifically. it assumes an OpenAI-style contract.
-
-## automation
-
-github actions now handle the basic release path for the repo. pushes and pull requests run lint, tests, package builds, and a CLI smoke check. version tags matching `v*` build release artifacts and attach them to a github release. pypi publishing is wired for trusted publishing as an opt-in path, and only runs when the repository variable `PYPI_PUBLISH=true` is set and the repository has been registered as a trusted publisher on pypi.
 ## license
 
-mit
+MIT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# Architecture Overview
+
+Traccia is a pipeline over local files. It keeps raw inputs, evidence, graph
+state, and rendered outputs separate so the system can explain each skill claim
+and publish selectively.
+
+## Data Flow
+
+```text
+source files
+  -> discovery and source-family detection
+  -> raw import
+  -> parsing and span storage
+  -> evidence extraction
+  -> canonical skill matching
+  -> person-skill scoring
+  -> graph rendering
+  -> markdown, profile, Obsidian, viewer, and public publish exports
+```
+
+## Boundaries
+
+| Boundary | Rule |
+| --- | --- |
+| Raw input | The LLM never rewrites files in `raw/`. |
+| Extraction | First-pass extraction sees one source or source chunk. |
+| Evidence | Evidence records are durable and tied to source IDs and spans. |
+| Graph | Scoring reads stored evidence and writes canonical graph state. |
+| Rendering | Markdown, JSON, profile, and viewers are projections. |
+| Publishing | Public bundles are separate redacted contracts, not lightly filtered admin data. |
+
+## Evidence Model
+
+Each evidence item stores:
+
+- Source ID and span offsets.
+- Exact supporting quote.
+- Evidence type, such as implemented, debugged, studied, or self-claimed.
+- Signal class, such as artifact-backed work or ambient interest.
+- Candidate skills and artifacts.
+- Time reference.
+- Reliability tier.
+- Extractor version and confidence.
+
+This makes weak signals usable without allowing them to inflate mastery.
+
+## Scoring Model
+
+The current support score is:
+
+```text
+support = evidence_type_weight * signal_class_multiplier * confidence
+```
+
+High-signal actions include implementation, debugging, design, review,
+teaching, and presenting when they are backed by artifact or problem-solving
+evidence. Passive signals such as mentions, self-claims, and studying can show
+awareness but cannot independently imply deep competence.
+
+Consumption-led evidence is capped at level 2 by default.
+
+## Freshness
+
+Freshness is currently stepwise:
+
+| Latest evidence age | Recency score | Freshness |
+| --- | --- | --- |
+| 0-90 days | `1.0` | `active` |
+| 91-180 days | `0.7` | `warming` |
+| 181-365 days | `0.4` | `stale` |
+| Older | `0.15` | `historical` |
+
+## Review And Overrides
+
+Human curation is stored separately from automatic extraction and scoring.
+
+Overrides can:
+
+- Accept or reject review items.
+- Lock skills.
+- Hide skills.
+- Add aliases.
+- Apply viewer curation before publishing.
+
+Manual state is part of the graph state and survives rendering.
+
+## Failure And Resume Model
+
+Ingest progress, manifests, extraction checkpoints, scoring progress, and run
+telemetry are written under `state/`. Re-running an interrupted ingest should
+resume from durable records rather than starting from zero.
+
+The pipeline deliberately separates extraction from graph scoring. This allows
+staged ingest, `--score-mode none`, and later scoring from stored evidence.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,95 @@
+# CLI Reference
+
+The console script is `traccia`. In a source checkout you can also run
+`uv run traccia`.
+
+Most commands accept `--project-root`. If omitted, the current directory is the
+project root.
+
+## Project Commands
+
+| Command | Purpose |
+| --- | --- |
+| `traccia init [PATH]` | Create a project scaffold, config, prompts, empty graph files, and SQLite catalog. |
+| `traccia lint [PATH]` | Validate `config/config.yaml` against the config schema. |
+| `traccia doctor [PATH]` | Check scaffold files, backend settings, optional parsers, OCR, media tools, and auth. |
+| `traccia doctor [PATH] --check-backend` | Also run an authenticated backend healthcheck. |
+| `traccia stats --project-root PATH` | Print source, skill, evidence, and review counts. |
+
+## Intake Commands
+
+| Command | Purpose |
+| --- | --- |
+| `traccia add FILE --project-root PATH` | Import a file into `raw/imported/` without running the full evidence pipeline. |
+| `traccia add-dir DIR --project-root PATH` | Import a directory into `raw/imported/` without the full evidence pipeline. |
+| `traccia ingest FILE --project-root PATH` | Parse, extract evidence, score, and render one file. |
+| `traccia ingest-dir DIR --project-root PATH` | Discover and process a directory or archive tree. |
+| `traccia stage-dir DIR --project-root PATH` | Discover, import, and parse materials without LLM extraction or graph sync. |
+| `traccia discover-dir DIR --project-root PATH` | Preview material counts and source-family detection. |
+| `traccia reingest SOURCE_ID --project-root PATH` | Reprocess one tracked source. |
+| `traccia watch DIR --project-root PATH` | Poll a directory for new files and ingest changes. |
+| `traccia merge-project SOURCE_PROJECT --project-root TARGET` | Merge source and evidence records from another Traccia project. |
+
+Common `ingest-dir` options:
+
+| Option | Meaning |
+| --- | --- |
+| `--import-prefix PATH` | Preserve stable source IDs when ingesting a subfolder from a larger archive. |
+| `--no-sync-graph` | Extract evidence without recomputing rendered graph projections. |
+| `--no-sync-deletions` | Do not mark previously tracked files in the import scope as deleted. |
+| `--parallel-extractions N` | Run multiple material-level extraction workers inside one ingest process. |
+| `--score-mode incremental` | Reuse unchanged graph scoring work. This is the default. |
+| `--score-mode full` | Recompute canonicalization and scoring from stored evidence. |
+| `--score-mode none` | Store sources and evidence only; run `traccia score` later. |
+
+## Scoring And Rendering
+
+| Command | Purpose |
+| --- | --- |
+| `traccia score --project-root PATH` | Recompute graph scoring and render projections. |
+| `traccia score --mode full --project-root PATH` | Ignore score caches and recompute graph decisions. |
+| `traccia score --parallel-scores N --project-root PATH` | Run bounded parallel skill scoring. |
+| `traccia rebuild --project-root PATH` | Rebuild derived outputs through the pipeline. |
+| `traccia render --project-root PATH` | Render markdown, JSON, profile, and debug outputs from stored graph state. |
+
+## Reading The Graph
+
+| Command | Purpose |
+| --- | --- |
+| `traccia tree --project-root PATH` | Print an ASCII tree. |
+| `traccia tree --format mermaid --project-root PATH` | Print a Mermaid graph. |
+| `traccia node SKILL_ID --project-root PATH` | Print one generated node page. |
+| `traccia explain SKILL_OR_ALIAS --project-root PATH` | Print the node page found by skill ID, name, or alias. |
+| `traccia why SKILL_ID --project-root PATH` | Alias for `explain`. |
+| `traccia evidence SKILL_ID --project-root PATH` | Print evidence records that support a skill. |
+
+## Review And Curation
+
+| Command | Purpose |
+| --- | --- |
+| `traccia review --project-root PATH` | List pending review items. |
+| `traccia review --accept ITEM_ID --project-root PATH` | Accept a review item and update the graph. |
+| `traccia review --reject ITEM_ID --project-root PATH` | Reject a review item. |
+| `traccia lock SKILL_ID --project-root PATH` | Add a manual lock override for a skill. |
+| `traccia hide SKILL_ID --project-root PATH` | Hide a skill in graph state. |
+| `traccia alias add SKILL_ID ALIAS --project-root PATH` | Add a manual alias for a skill. |
+
+## Export Commands
+
+| Command | Output |
+| --- | --- |
+| `traccia export graph --project-root PATH` | Refresh and print `graph/graph.json`. |
+| `traccia export profile --project-root PATH` | Refresh and print `profile/skill.md`. |
+| `traccia export skill-md --project-root PATH` | Refresh and print `tree/nodes/`. |
+| `traccia export obsidian --project-root PATH` | Write `exports/obsidian/`. |
+| `traccia export debug-report --project-root PATH` | Write `exports/debug/report.json` and `exports/debug/report.md`. |
+| `traccia export viewer --project-root PATH` | Write `exports/viewer/`. |
+| `traccia export admin --project-root PATH` | Write `exports/viewer-admin/`. |
+| `traccia export publish --project-root PATH` | Write `exports/viewer-public/` by default. |
+
+Viewer export options:
+
+| Option | Meaning |
+| --- | --- |
+| `--no-sound` | Disable viewer SFX by default. |
+| `--output-dir NAME` | For `publish`, choose the output directory under `exports/`. |

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -1,0 +1,133 @@
+# Codebase Map
+
+This map covers the tracked repository files that define Traccia's behavior,
+packaging, tests, and documentation. Generated caches, local virtual
+environments, and temporary project outputs are not product surface. For the
+tracked file inventory with line counts, see [Repository inventory](repository-inventory.md).
+
+## Root Files
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | Short product overview, install paths, and documentation entry points. |
+| `pyproject.toml` | Python package metadata, dependencies, optional extras, console script, pytest, and Ruff config. |
+| `uv.lock` | Locked Python dependency graph for the `uv` workflow. |
+| `package.json` | npm package metadata for the thin `@microck/traccia` launcher. |
+| `LICENSE` | MIT license. |
+| `CONTRIBUTING.md` | Contributor workflow notes. |
+| `CODEOWNERS` | Repository ownership. |
+| `CLAUDE.md` | Generated or maintained agent guidance for the project context. |
+| `.python-version` | Local Python version pin. |
+| `.gitignore` | Local ignore rules. |
+
+## Python Package
+
+| File | Responsibility |
+| --- | --- |
+| `src/traccia/__init__.py` | Package version surface. |
+| `src/traccia/__main__.py` | `python -m traccia` entrypoint. |
+| `src/traccia/bootstrap.py` | Project scaffolding, default prompts, initial files, and SQLite schema. |
+| `src/traccia/cli.py` | Typer CLI commands and command-level orchestration. |
+| `src/traccia/config.py` | Pydantic configuration models and YAML load/write helpers. |
+| `src/traccia/curation.py` | Viewer curation and public publish redaction logic. |
+| `src/traccia/document_normalizer.py` | PDF/DOCX markdown normalization provider chain. |
+| `src/traccia/extraction.py` | Evidence extraction contracts and extractor integration. |
+| `src/traccia/family_normalizer.py` | Source-family-specific normalization for exported data shapes. |
+| `src/traccia/fixtures.py` | Fixture helpers for tests and golden data. |
+| `src/traccia/google_takeout.py` | Deterministic Google Takeout relevance and product policy. |
+| `src/traccia/llm.py` | Backend abstraction, structured calls, retries, leases, and healthchecks. |
+| `src/traccia/models.py` | Strict Pydantic domain models and enums. |
+| `src/traccia/parsers.py` | Parser registry, source parsing, spans, attachments, and chunking. |
+| `src/traccia/pipeline.py` | End-to-end pipeline orchestration for ingest, discovery, scoring, resume, and graph sync. |
+| `src/traccia/pipeline_support.py` | Support scoring, strong-action detection, node creation, review, and state scoring helpers. |
+| `src/traccia/rendering.py` | Graph JSON, tree markdown, profile, Obsidian, and debug report rendering. |
+| `src/traccia/source_detection.py` | Source family and source type detection. |
+| `src/traccia/storage.py` | SQLite persistence, schema checks, queries, merge, review, overrides, and caches. |
+| `src/traccia/taxonomy.py` | Built-in seed taxonomy and skill aliases. |
+| `src/traccia/utils.py` | Shared IDs, slugs, timestamps, hashes, and small text helpers. |
+| `src/traccia/viewer.py` | Static viewer, admin viewer, and publish export assembly. |
+| `src/traccia/viewer_assets.py` | Embedded HTML/CSS/JS assets for the static viewer. |
+
+## Assets
+
+| Path | Purpose |
+| --- | --- |
+| `src/traccia/assets/favicon.svg` | Viewer/package favicon. |
+| `src/traccia/assets/fonts/README.md` | Notes for bundled font assets. |
+| `src/traccia/assets/fonts/*.ttf` | Bundled display, UI, label, and mono font files. |
+| `.github/assets/traccia-logo.svg` | README and repository logo. |
+
+## npm Launcher
+
+| File | Purpose |
+| --- | --- |
+| `npm/bin/traccia.js` | Node launcher that runs `uvx --from traccia traccia ...`; maintainer mode uses `TRACCIA_USE_LOCAL_REPO=1` to run `uv run traccia ...` from a checkout. |
+
+Environment variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `TRACCIA_UVX_SPEC` | Override the `uvx --from` package spec, for example `traccia[document-markdown]`. |
+| `TRACCIA_USE_LOCAL_REPO=1` | Run the local checkout with `uv run traccia ...` instead of `uvx`. |
+
+## Scripts
+
+| File | Purpose |
+| --- | --- |
+| `scripts/check-viewer-performance.mjs` | Browser-side performance check for exported viewer assets. |
+
+Scripts are tracked for maintainer use but are not shipped in the Python sdist
+according to `pyproject.toml`.
+
+## Tests
+
+| File | Covers |
+| --- | --- |
+| `tests/test_config.py` | Config defaults and validation. |
+| `tests/test_error_messages.py` | User-facing error message behavior. |
+| `tests/test_extraction.py` | Evidence extraction and validation. |
+| `tests/test_fixtures.py` | Fixture loading. |
+| `tests/test_init.py` | Project initialization, scaffold files, and doctor behavior. |
+| `tests/test_llm.py` | Backend behavior, structured outputs, retries, and leases. |
+| `tests/test_models.py` | Pydantic domain model contracts. |
+| `tests/test_npm_wrapper.py` | npm launcher behavior and failure messages. |
+| `tests/test_parsers.py` | Parser registry, source parsing, attachments, and normalization. |
+| `tests/test_pipeline.py` | End-to-end ingest, scoring, review, staging, deletion, and resume behavior. |
+| `tests/test_signal_handling.py` | Signal handling and interruption behavior. |
+| `tests/test_source_detection.py` | Source family/type detection. |
+| `tests/test_storage.py` | SQLite persistence behavior. |
+| `tests/test_utils.py` | Shared utility helpers. |
+| `tests/test_viewer.py` | Viewer, admin curation, public publish, and redaction contracts. |
+
+Fixtures live under `tests/fixtures/` and include a small corpus plus golden JSON
+contracts for sources, evidence, skills, manifests, and config.
+
+## GitHub Workflows
+
+| File | Purpose |
+| --- | --- |
+| `.github/workflows/ci.yml` | CI checks for the Python package and tests. |
+| `.github/workflows/release.yml` | Release packaging workflow. |
+| `.github/workflows/security.yml` | Security-oriented workflow checks. |
+| `.github/dependabot.yml` | Dependency update configuration. |
+
+## Documentation Files
+
+| File | Purpose |
+| --- | --- |
+| `docs/index.md` | Documentation table of contents. |
+| `docs/quickstart.md` | First successful local project flow. |
+| `docs/cli-reference.md` | Command reference. |
+| `docs/project-layout.md` | Project directories and artifacts. |
+| `docs/configuration.md` | Config schema guide. |
+| `docs/ingestion.md` | Ingest, staging, scoring, source families, and resume. |
+| `docs/exports.md` | Markdown, Obsidian, viewer, admin, and publish exports. |
+| `docs/architecture.md` | System model and boundaries. |
+| `docs/development.md` | Maintainer workflow. |
+| `docs/spec.md` | Detailed product specification. |
+| `docs/architecture-notes.md` | Implementation-level notes. |
+| `docs/ingest-architecture.md` | Detailed ingest architecture. |
+| `docs/finished-run-viewer-decisions.md` | Viewer design decisions. |
+| `docs/plan.md` | Original phased build plan. |
+| `docs/decisions.md` | Planning and product decisions. |
+| `docs/references.md` | External references and anti-references. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,193 @@
+# Configuration Reference
+
+Project configuration lives at `config/config.yaml` inside a Traccia project.
+The schema is defined in `src/traccia/config.py` and validated by Pydantic.
+
+Run validation with:
+
+```bash
+traccia lint my-traccia
+traccia doctor my-traccia
+```
+
+## Core Fields
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `schema_version` | `1` | Config schema version. |
+| `project_name` | `traccia` | Display name for the project. |
+| `paths` | see below | Project directory names. |
+| `pipeline` | `phase-0` versions | Parser, extractor, canonicalizer, scorer, and renderer versions. |
+
+Default paths:
+
+```yaml
+paths:
+  raw_inbox: raw/inbox
+  raw_imported: raw/imported
+  parsed: parsed
+  evidence: evidence
+  graph: graph
+  tree: tree
+  profile: profile
+  state: state
+  exports: exports
+```
+
+## Backend
+
+The default backend is an OpenAI-compatible chat completions endpoint:
+
+```yaml
+backend:
+  provider: openai_compatible
+  model: gpt-5-chat-latest
+  api_key_env: OPENAI_API_KEY
+  base_url: https://api.openai.com/v1
+  api_style: chat_completions
+  structured_output_mode: json_schema
+  supports_vision: false
+  vision_detail: auto
+  timeout_seconds: 60
+  max_retries: 3
+```
+
+For deterministic tests:
+
+```yaml
+backend:
+  provider: fake
+```
+
+## Extraction Lane Pool
+
+Use `backend.extraction_backends` when evidence extraction should use multiple
+OpenAI-style backends while canonicalization and scoring stay on the primary
+backend.
+
+```yaml
+backend:
+  provider: openai_compatible
+  model: glm-5-turbo
+  api_key_env: CLIPROXYAPI_KEY
+  base_url: http://127.0.0.1:8317/v1
+  extraction_backends:
+    - name: glm
+      model: glm-5-turbo
+      api_key_env: CLIPROXYAPI_KEY
+      base_url: http://127.0.0.1:8317/v1
+      parallel_extractions: 5
+    - name: gemini
+      model: star-gemini-3.5-flash
+      api_key_env: CLIPROXYAPI_KEY
+      base_url: http://127.0.0.1:8317/v1
+      supports_vision: true
+      parallel_extractions: 3
+```
+
+## Ingest And Scoring
+
+```yaml
+ingest:
+  parallel_extractions: 1
+
+graph_scoring:
+  parallel_scores: 1
+
+graph_refresh:
+  live_checkpoints_enabled: false
+  live_checkpoint_material_interval: 25
+  live_checkpoint_min_interval_seconds: 1800.0
+  small_run_live_checkpoint_material_limit: 10
+```
+
+`parallel_extractions` controls material-level evidence extraction inside one
+ingest process. `parallel_scores` controls final per-skill scoring. Discovery,
+manifest writes, graph cache writes, progress writes, and final rendering stay
+parent-side serialized.
+
+## Thresholds
+
+```yaml
+thresholds:
+  strong_evidence_auto_create: 0.85
+  review_confidence_floor: 0.6
+  consumption_max_level: 2
+```
+
+Consumption-led evidence can show awareness or study, but it cannot push a skill
+beyond the configured maximum without stronger action evidence.
+
+## Privacy
+
+```yaml
+privacy:
+  default_sensitivity: private
+  redact_source_paths_in_exports: true
+  allow_raw_excerpt_export: false
+```
+
+The defaults avoid raw paths and raw excerpts in rendered exports. The public
+publish export applies stronger filtering and writes a separate redacted bundle.
+
+## Document Normalization
+
+```yaml
+document_normalization:
+  provider: auto
+  ocr_provider: auto
+```
+
+PDF and DOCX inputs pass through document normalization. Optional extras add
+heavier local providers:
+
+```bash
+uv sync --extra docling
+uv sync --extra marker
+uv sync --extra document-markdown
+```
+
+## Multimodal
+
+```yaml
+multimodal:
+  enable_linked_attachments: true
+  enable_vision: false
+  enable_local_image_ocr: true
+  enable_local_media_transcription: true
+  enable_remote_media_enrichment: true
+  audio_transcription_provider: auto
+  audio_transcription_model: turbo
+  audio_transcription_device: cpu
+  remote_media_enrichment_command: summarize
+  remote_media_enrichment_video_mode: understand
+  enable_remote_media_slides: true
+  enable_remote_media_slides_ocr: true
+  max_attachments_per_source: 4
+  max_attachment_text_characters: 1200
+  max_attachment_transcript_characters: 8000
+  max_image_bytes: 5000000
+  ocr_timeout_seconds: 20
+  transcription_timeout_seconds: 1800
+  remote_media_enrichment_timeout_seconds: 180
+```
+
+If image context requires vision and the active backend does not support it,
+Traccia delays the material rather than silently treating OCR-only text as
+equivalent.
+
+## Google Takeout
+
+```yaml
+google_takeout:
+  relevance_mode: skill_relevant
+  gmail_mode: metadata_plus_sent
+  youtube_enrichment: detailed
+  photos_mode: fast_vision
+  drive_mode: selective_docs
+  max_photo_vision_samples_per_folder: 8
+```
+
+The Google Takeout policy is deterministic and runs before model calls. It is
+designed to keep zero-value account metadata, caches, raw binaries, sidecars,
+and bulk runtime data from spending model quota.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,114 @@
+# Development Guide
+
+This page is for maintainers working on the Traccia repository.
+
+## Setup
+
+```bash
+uv sync
+```
+
+Run the CLI from the checkout:
+
+```bash
+uv run traccia --help
+```
+
+Install the editable console script:
+
+```bash
+uv tool install -e .
+```
+
+## Tests And Lint
+
+Run tests:
+
+```bash
+uv run pytest
+```
+
+Run Ruff:
+
+```bash
+uv run ruff check .
+```
+
+The configured test path is `tests/`. Ruff targets Python 3.12 and uses a
+100-column line length.
+
+## Package Metadata
+
+The Python package is defined in `pyproject.toml`:
+
+- Package name: `traccia`.
+- Console script: `traccia = "traccia.cli:app"`.
+- Python range: `>=3.12,<3.14`.
+- Build backend: Hatchling.
+- Runtime dependencies: Pydantic, PyYAML, Typer, pypdf, python-docx, openpyxl,
+  and lxml.
+
+Optional extras:
+
+| Extra | Adds |
+| --- | --- |
+| `docling` | Docling document conversion. |
+| `marker` | Marker PDF conversion. |
+| `markitdown` | MarkItDown conversion. |
+| `document-markdown` | Full local document normalization stack. |
+
+## npm Wrapper
+
+The npm package is `@microck/traccia`. It does not contain a JavaScript
+implementation of Traccia. It launches the Python CLI through `uvx`:
+
+```bash
+npx @microck/traccia doctor .
+```
+
+Maintainer mode runs the local checkout:
+
+```bash
+TRACCIA_USE_LOCAL_REPO=1 node npm/bin/traccia.js doctor .
+```
+
+To test a different Python package spec:
+
+```bash
+TRACCIA_UVX_SPEC='traccia[document-markdown]' npx @microck/traccia doctor .
+```
+
+## High-Risk Areas
+
+| Area | Why it needs careful tests |
+| --- | --- |
+| `pipeline.py` | Orchestrates discovery, extraction, resume, scoring, deletion sync, and rendering. |
+| `storage.py` | Owns SQLite persistence and additive schema checks. |
+| `llm.py` | Owns backend calls, retries, structured output, and LLM request leases. |
+| `parsers.py` | Encodes messy file and attachment parsing rules. |
+| `family_normalizer.py` | Normalizes provider export formats. |
+| `rendering.py` | Turns canonical graph state into user-facing projections. |
+| `viewer.py` and `viewer_assets.py` | Own static viewer export, curation, performance, and public redaction contracts. |
+
+Prefer behavior tests over implementation-only tests. If a change affects public
+CLI behavior, generated artifacts, config schema, persistence format, or export
+redaction, update the corresponding docs and tests in the same patch.
+
+## Release Surface
+
+The source distribution includes:
+
+- `.github/assets`
+- `CODEOWNERS`
+- `CONTRIBUTING.md`
+- `LICENSE`
+- `README.md`
+- `docs`
+- `npm`
+- `package.json`
+- `pyproject.toml`
+- `src`
+- `tests`
+
+The build excludes local caches, virtual environments, `dist`, scripts, and
+temporary project outputs.

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -1,0 +1,131 @@
+# Exports And Publishing
+
+Traccia renders several projections from the same canonical graph state. Exports
+are generated files, not the source of truth.
+
+## Local Graph Exports
+
+| Command | Output | Use it for |
+| --- | --- | --- |
+| `traccia export graph` | `graph/graph.json` | Machine-readable graph payload. |
+| `traccia export profile` | `profile/skill.md` | Profile summary derived from graph state. |
+| `traccia export skill-md` | `tree/nodes/` | One markdown page per skill. |
+| `traccia tree` | terminal output | Quick CLI inspection. |
+| `traccia tree --format mermaid` | terminal Mermaid | Lightweight diagram embedding. |
+
+## Obsidian Export
+
+```bash
+traccia export obsidian --project-root my-traccia
+```
+
+Output:
+
+```text
+exports/obsidian/
+  Skills/
+  Domains/
+  Evidence/
+  Sources/
+  Profiles/
+  Graph/
+```
+
+The Obsidian export copies graph data and writes linked markdown notes for
+browsing outside the CLI.
+
+## Debug Report
+
+```bash
+traccia export debug-report --project-root my-traccia
+```
+
+The debug report is for maintainers and operators. It includes counts and
+diagnostics without making raw source files the public interface.
+
+## Public Viewer
+
+```bash
+traccia export viewer --project-root my-traccia
+```
+
+Output:
+
+```text
+exports/viewer/
+```
+
+The read-only viewer is a static skill map generated from the current graph. It
+includes pan and zoom, search, filters, minimap, legend, node details, deep
+links, responsive mobile surfaces, and optional procedural UI sound.
+
+Public search covers skill names, areas/domains, and descriptions. It does not
+search raw provenance or aliases because the public graph contract strips alias
+data.
+
+Disable sound by default:
+
+```bash
+traccia export viewer --project-root my-traccia --no-sound
+```
+
+## Admin Curation Viewer
+
+```bash
+traccia export admin --project-root my-traccia
+```
+
+Output:
+
+```text
+exports/viewer-admin/
+```
+
+The admin viewer includes the full internal graph, including hidden, disputed,
+review, and low-confidence nodes. It can write curation decisions such as:
+
+- Hide or restore a node.
+- Mute a node.
+- Feature or pin a node.
+- Collapse or expand domains.
+- Add public label or note overrides.
+- Approve selected low-confidence or disputed nodes for publication.
+
+When served locally, the save action writes `curation.json`. From a static file
+server, the browser downloads `curation.json`; place it where publish expects it.
+
+## Publish A Redacted Public Bundle
+
+```bash
+traccia export publish --project-root my-traccia
+```
+
+Default output:
+
+```text
+exports/viewer-public/
+```
+
+Choose another directory name under `exports/`:
+
+```bash
+traccia export publish --project-root my-traccia --output-dir public-map
+```
+
+Publish reads graph state plus `exports/viewer/curation.json`, applies curation
+and redaction rules, and writes a separate public graph contract.
+
+The public bundle excludes:
+
+- Hidden nodes and hidden edges.
+- Raw source paths.
+- Raw excerpts.
+- Sensitive evidence IDs.
+- Private or redacted provenance.
+- Disputed or review nodes unless explicitly approved.
+- Low-confidence nodes unless explicitly approved.
+
+Public node IDs remain the same as internal IDs unless an ID leaks private
+information. In that case, publish generates stable `pub_<hash>` aliases and
+keeps the mapping in `alias-map.json` next to the public bundle. That file is
+admin-only and must not be deployed publicly.

--- a/docs/finished-run-viewer-decisions.md
+++ b/docs/finished-run-viewer-decisions.md
@@ -68,7 +68,7 @@ It is a design handoff for execution, not an implementation spec.
     Desktop uses a HUD-aligned selection dock instead of a full-height drawer;
     mobile uses an expandable bottom sheet.
 34. Support domain collapse/expand in both public and admin viewers. Public collapse state is temporary per browser session; admin default collapse state can be saved into `curation.json`.
-35. Search should match skill names, aliases, domains, and descriptions in v1. Do not search raw provenance or evidence in the public viewer unless public-safe summaries are added later.
+35. Search should match skill names, domains, areas, and descriptions in v1. Do not search aliases, raw provenance, or evidence in the public viewer unless public-safe summaries are added later.
 36. Keep search always visible, and keep domain, status, freshness,
     confidence, and evidence type reachable through a compact collapsible HUD
     filter panel instead of a full-width filter bar.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,49 @@
+# Traccia Documentation
+
+Traccia is a local-first CLI that compiles a personal archive into an
+evidence-backed skill graph. The docs are split by reader task: start with the
+quickstart, then use the reference pages when you need exact commands or file
+contracts.
+
+## Start Here
+
+| Page | Use it when |
+| --- | --- |
+| [Quickstart](quickstart.md) | You want to create a project, ingest files, and inspect the first graph. |
+| [CLI reference](cli-reference.md) | You need the exact command surface and common options. |
+| [Project layout](project-layout.md) | You want to understand what a Traccia project stores. |
+| [Ingestion guide](ingestion.md) | You are importing folders, archives, exports, or long-running datasets. |
+| [Configuration reference](configuration.md) | You are changing backend, privacy, multimodal, or performance settings. |
+| [Exports and publishing](exports.md) | You want markdown, Obsidian, graph JSON, or the public viewer. |
+| [Architecture overview](architecture.md) | You want the system model and data flow. |
+| [Codebase map](codebase-map.md) | You are maintaining the repository and need module ownership. |
+| [Repository inventory](repository-inventory.md) | You want the tracked file inventory and line-count audit. |
+| [Development guide](development.md) | You want to run tests, package the CLI, or work on the repo. |
+
+## Deeper Records
+
+These files capture planning and design history. They are useful for maintainers
+but are not the best entry point for a new user.
+
+| File | Contents |
+| --- | --- |
+| [Spec](spec.md) | Product scope, goals, non-goals, input model, and output contracts. |
+| [Architecture notes](architecture-notes.md) | Implementation decisions and high-risk modules. |
+| [Ingest architecture](ingest-architecture.md) | Detailed ingest, staging, scoring, and source-family decisions. |
+| [Viewer decisions](finished-run-viewer-decisions.md) | Public/admin viewer design decisions. |
+| [Plan](plan.md) | Original phased implementation plan. |
+| [Decisions](decisions.md) | Product and architecture decisions from planning. |
+| [References](references.md) | External project references and anti-references. |
+
+## Mental Model
+
+Traccia has three separate layers:
+
+```text
+raw files -> parsed spans -> evidence -> scored graph -> rendered exports
+```
+
+The raw archive is not the graph. The graph is a derived projection over stored
+evidence, and exports are projections over the graph. This separation is the
+main reason Traccia can explain why a skill exists and can publish a redacted
+view without exposing private source material.

--- a/docs/ingest-architecture.md
+++ b/docs/ingest-architecture.md
@@ -90,7 +90,7 @@ The config default is:
 
 ```yaml
 graph_scoring:
-  parallel_scores: 4
+  parallel_scores: 1
 ```
 
 This pool is deliberately narrower than running multiple scorer processes. The

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -1,0 +1,153 @@
+# Ingestion Guide
+
+Ingestion turns files into source records, spans, evidence, graph state, and
+rendered outputs. The main contract is source-scoped extraction: the first LLM
+pass sees one source or one source chunk, not the whole archive.
+
+## Flow
+
+```text
+discover -> classify family -> import raw material -> parse spans
+  -> extract evidence -> store evidence -> score graph -> render exports
+```
+
+The graph is not updated from a lossy batch summary. It is recomputed from
+durable source and evidence records in `state/catalog.sqlite`.
+
+## Preview A Directory
+
+```bash
+traccia discover-dir /path/to/archive --project-root my-traccia
+traccia discover-dir /path/to/archive --project-root my-traccia --format json
+```
+
+Discovery reports material counts, direct files, archive members, source
+families, and source-family subproducts.
+
+## Full Directory Ingest
+
+```bash
+traccia ingest-dir /path/to/archive --project-root my-traccia
+```
+
+This is the normal path. It discovers, imports, parses, extracts evidence,
+scores the graph, renders outputs, and syncs deletions in the import scope.
+
+For a mounted archive or a subfolder that should keep stable source IDs, pass
+an import prefix:
+
+```bash
+traccia ingest-dir /mnt/gdrive2/rrss-data/08042026/Twitter \
+  --project-root my-traccia \
+  --import-prefix rrss-data/08042026/Twitter
+```
+
+## Staged Ingest
+
+Use staging when a long graph scoring run is already active or when you want to
+prepare filesystem work without model calls:
+
+```bash
+traccia stage-dir /path/to/archive --project-root my-traccia
+```
+
+`stage-dir` discovers, classifies, imports, parses, stores source/span records,
+writes manifests, and checkpoints progress. It does not extract evidence,
+recompute the graph, or mark deletions.
+
+Later, run normal ingest against the same scope to extract evidence and update
+the graph.
+
+## Extract Without Graph Sync
+
+If you want evidence extraction but not graph scoring:
+
+```bash
+traccia ingest-dir /path/to/archive \
+  --project-root my-traccia \
+  --no-sync-graph \
+  --no-sync-deletions
+```
+
+Or use:
+
+```bash
+traccia ingest-dir /path/to/archive --project-root my-traccia --score-mode none
+```
+
+Then score later:
+
+```bash
+traccia score --project-root my-traccia
+```
+
+## Scoring Modes
+
+| Mode | Use it for |
+| --- | --- |
+| `incremental` | Normal operation. Reuses unchanged candidate and skill score caches. |
+| `full` | Audits, repairs, prompt/model changes, or scoring behavior changes. |
+| `none` | Ingest source/evidence records without graph scoring. Available on ingest commands. |
+
+Examples:
+
+```bash
+traccia score --mode incremental --project-root my-traccia
+traccia score --mode full --project-root my-traccia
+traccia ingest-dir /path/to/archive --project-root my-traccia --score-mode none
+```
+
+## Parallelism
+
+Evidence extraction can use a bounded material-level worker pool:
+
+```bash
+traccia ingest-dir /path/to/archive --project-root my-traccia --parallel-extractions 4
+```
+
+Skill scoring can use a separate bounded worker pool:
+
+```bash
+traccia score --project-root my-traccia --parallel-scores 4
+```
+
+These settings spend quota faster. They do not merge materials into one prompt,
+and they do not make graph writes concurrent.
+
+## Source Families
+
+Discovery classifies materials before parsing. Current families are:
+
+| Family | Examples |
+| --- | --- |
+| `generic` | Markdown, text, code, loose CSV/JSON, ordinary documents. |
+| `google_takeout` | `Takeout/`, `archive_browser.html`, Google product export trees. |
+| `discord_data_package` | Discord account and message package layouts. |
+| `twitter_archive` | X/Twitter archive files such as `data/account.js` and `data/tweets.js`. |
+| `reddit_export` | Reddit comments, posts, and conversations exports. |
+| `instagram_export` | Instagram export bundles and Meta account download subtrees. |
+| `facebook_export` | Facebook export bundles and Meta account download subtrees. |
+
+Unknown layouts fall back to `generic`.
+
+## Linked Attachments And Vision
+
+Linked images, video, audio, documents, and links belong to the parent source
+context. If vision is required and the active backend is not vision-capable,
+Traccia marks the material as delayed instead of extracting lower-quality text
+alone.
+
+To process delayed image-heavy materials, enable vision and use a backend with
+`supports_vision: true`.
+
+## Progress Files
+
+| File | Meaning |
+| --- | --- |
+| `state/progress.json` | Current ingest progress and material status. |
+| `state/manifests/<ingest-id>.json` | Discovery and processing outcomes for one run. |
+| `state/graph-score-progress.json` | Active graph scoring progress. |
+| `state/graph-score-runs.jsonl` | Append-only graph scoring run telemetry. |
+
+Re-run the same ingest command after a crash, quota issue, or mount interruption.
+The pipeline uses durable source, parsed, evidence, and progress state to resume.

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -1,0 +1,72 @@
+# Project Layout
+
+A Traccia project is a folder created by `traccia init`. Raw inputs, parsed
+spans, evidence, graph state, rendered markdown, and exports live in separate
+directories.
+
+## Top-Level Directories
+
+| Path | Owner | Meaning |
+| --- | --- | --- |
+| `config/` | User and CLI | Project configuration. |
+| `config/prompts/` | Maintainer and CLI | Prompt contracts for extraction, canonicalization, scoring, and rendering. |
+| `raw/inbox/` | User | Optional drop zone for source files. |
+| `raw/imported/` | Pipeline | Imported source files or links. Raw content is not rewritten by the LLM. |
+| `parsed/` | Pipeline | Parsed source documents and spans. |
+| `evidence/` | Pipeline | Per-source evidence extraction artifacts. |
+| `graph/` | Renderer | Machine-readable graph projections. |
+| `tree/` | Renderer | Markdown skill tree pages. |
+| `profile/` | Renderer | Profile projection derived from graph state. |
+| `state/` | Pipeline and storage | SQLite catalog, manifests, progress, review queue, and run telemetry. |
+| `exports/` | Export commands | Obsidian vault, debug report, viewer bundles, and publish outputs. |
+
+## Canonical State
+
+`state/catalog.sqlite` is the canonical derived state. The graph JSON, markdown
+tree, profile, Obsidian export, and static viewers are render outputs.
+
+Important SQLite tables are initialized by `src/traccia/bootstrap.py` and
+managed by `src/traccia/storage.py`:
+
+| Table | Meaning |
+| --- | --- |
+| `sources` | Imported source records, metadata, source family, status, and fingerprints. |
+| `source_spans` | Parsed offsets for source-local evidence boundaries. |
+| `evidence_items` | Evidence extracted from one source or source chunk. |
+| `skills` | Canonical skill nodes. |
+| `skill_aliases` | Lookup aliases for canonical skills. |
+| `skill_edges` | Parent, related, prerequisite, and other graph edges. |
+| `person_skill_states` | Level, confidence, freshness, centrality, and manual state for each skill. |
+| `review_queue` | Items requiring human accept/reject. |
+| `manual_overrides` | Locks, hides, aliases, and other explicit user decisions. |
+| `pipeline_runs` | Scoring and pipeline run summaries. |
+
+## Rendered Outputs
+
+| File | Meaning |
+| --- | --- |
+| `graph/graph.json` | Full graph projection for machine use and viewer export. |
+| `graph/tree.json` | Tree-shaped projection for terminal and markdown rendering. |
+| `tree/index.md` | Top-level markdown skill tree. |
+| `tree/log.md` | Ingest log. |
+| `tree/nodes/<skill-id>.md` | One markdown page per skill. |
+| `profile/skill.md` | Profile summary from accepted graph state. |
+| `profile/strengths.md` | Strengths projection derived from graph state. |
+| `profile/gaps.md` | Gaps projection derived from graph state. |
+| `profile/artifacts.md` | Artifact summary derived from graph state. |
+| `exports/debug/report.json` | Debug export with counts and pipeline diagnostics. |
+| `exports/debug/report.md` | Markdown version of the debug report. |
+
+## Progress And Recovery Files
+
+| File | Meaning |
+| --- | --- |
+| `state/progress.json` | Current directory/material ingest progress. |
+| `state/manifests/<ingest-id>.json` | Per-run discovery and material outcomes. |
+| `state/review_queue.jsonl` | File projection of pending review items. |
+| `state/graph-score-progress.json` | Current graph scoring progress. |
+| `state/graph-score-runs.jsonl` | Append-only graph scoring telemetry. |
+
+Crashes should not erase imported sources or accepted evidence. Re-run the same
+ingest command to resume from stored source, parsed, evidence, and progress
+state.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,122 @@
+# Quickstart
+
+This guide creates a local Traccia project, ingests a small folder, and shows
+the first useful outputs.
+
+## Requirements
+
+- Python 3.12.
+- `uv` for the recommended local workflow.
+- An OpenAI-compatible model endpoint for live extraction, unless you switch the
+  generated config to the fake backend for tests.
+
+Install dependencies from the repository:
+
+```bash
+uv sync
+```
+
+Install the CLI on `PATH` from the checkout:
+
+```bash
+uv tool install -e .
+```
+
+You can also run every command as `uv run traccia ...` from the repository.
+
+## Create A Project
+
+```bash
+traccia init my-traccia
+traccia doctor my-traccia
+```
+
+`init` creates the project layout, default config, prompts, empty graph files,
+and SQLite catalog. `doctor` checks that the scaffold exists and reports
+optional local capabilities such as document normalization, OCR, media tools,
+and backend authentication.
+
+## Configure The Backend
+
+Open `my-traccia/config/config.yaml`. The default backend is OpenAI-compatible:
+
+```yaml
+backend:
+  provider: openai_compatible
+  model: gpt-5-chat-latest
+  api_key_env: OPENAI_API_KEY
+  base_url: https://api.openai.com/v1
+```
+
+Set the required API key in your shell:
+
+```bash
+export OPENAI_API_KEY=...
+```
+
+For deterministic local tests, use:
+
+```yaml
+backend:
+  provider: fake
+```
+
+## Preview A Folder
+
+Before spending model quota, inspect what Traccia will treat as materials:
+
+```bash
+traccia discover-dir /path/to/archive --project-root my-traccia
+```
+
+For machine-readable output:
+
+```bash
+traccia discover-dir /path/to/archive --project-root my-traccia --format json
+```
+
+## Ingest Files
+
+Run a full directory ingest:
+
+```bash
+traccia ingest-dir /path/to/archive --project-root my-traccia
+```
+
+The default flow discovers materials, imports raw files, parses spans, extracts
+evidence, scores the graph, and renders projections.
+
+For one file:
+
+```bash
+traccia ingest /path/to/file.md --project-root my-traccia
+```
+
+## Inspect The Result
+
+```bash
+traccia stats --project-root my-traccia
+traccia tree --project-root my-traccia
+traccia explain python --project-root my-traccia
+traccia review --project-root my-traccia
+```
+
+Useful files:
+
+- `graph/graph.json` for the machine graph.
+- `tree/index.md` for the tree overview.
+- `tree/nodes/` for one markdown page per skill.
+- `profile/skill.md` for the profile projection.
+- `state/catalog.sqlite` for canonical derived state.
+
+## Export
+
+```bash
+traccia export obsidian --project-root my-traccia
+traccia export viewer --project-root my-traccia
+traccia export admin --project-root my-traccia
+traccia export publish --project-root my-traccia
+```
+
+The publish step reads curation from `exports/viewer/curation.json` and writes a
+separate redacted public bundle under `exports/viewer-public/`.

--- a/docs/repository-inventory.md
+++ b/docs/repository-inventory.md
@@ -1,0 +1,150 @@
+# Repository Inventory
+
+This inventory records the tracked files reviewed for the documentation pass.
+Line counts come from the current worktree with local caches, virtual
+environments, and temporary project outputs excluded.
+
+Total tracked lines at the time of this pass: `60435`.
+
+## Root And Project Metadata
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `.gitignore` | 43 | Local ignore rules. |
+| `.python-version` | 1 | Python version pin. |
+| `CLAUDE.md` | 177 | Project agent instructions and context. |
+| `CODEOWNERS` | 1 | Repository ownership. |
+| `CONTRIBUTING.md` | 38 | Contributor guidance. |
+| `LICENSE` | 21 | MIT license. |
+| `README.md` | 118 | Short product overview and docs entry point. |
+| `package.json` | 35 | npm launcher package metadata. |
+| `pyproject.toml` | 83 | Python package, dependency, build, test, and lint metadata. |
+| `uv.lock` | 2849 | Locked Python dependency graph. |
+
+## GitHub Metadata
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `.github/assets/traccia-logo.svg` | 28 | Repository logo used in the README. |
+| `.github/dependabot.yml` | 11 | Dependency update configuration. |
+| `.github/workflows/ci.yml` | 92 | CI workflow. |
+| `.github/workflows/release.yml` | 117 | Release workflow. |
+| `.github/workflows/security.yml` | 43 | Security workflow. |
+
+## User And Maintainer Docs
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `docs/index.md` | 48 | Documentation table of contents. |
+| `docs/quickstart.md` | 122 | First project tutorial. |
+| `docs/cli-reference.md` | 95 | CLI command reference. |
+| `docs/project-layout.md` | 72 | Project artifact layout reference. |
+| `docs/configuration.md` | 193 | Config schema guide. |
+| `docs/ingestion.md` | 153 | Ingestion, staging, scoring, and resume guide. |
+| `docs/exports.md` | 131 | Export, curation, and publish guide. |
+| `docs/architecture.md` | 94 | System architecture explanation. |
+| `docs/codebase-map.md` | 132 | Maintainer codebase map. |
+| `docs/repository-inventory.md` | this file | Tracked file and line-count audit. |
+| `docs/development.md` | 114 | Maintainer development guide. |
+
+## Design Records And Deep References
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `docs/architecture-notes.md` | 68 | Implementation notes and risk areas. |
+| `docs/decisions.md` | 277 | Product and architecture decision history. |
+| `docs/finished-run-viewer-decisions.md` | 435 | Viewer design and public export decision history. |
+| `docs/ingest-architecture.md` | 358 | Detailed ingest and scoring architecture record. |
+| `docs/plan.md` | 348 | Original phased implementation plan. |
+| `docs/references.md` | 105 | Related project references and anti-references. |
+| `docs/spec.md` | 933 | Full product specification. |
+
+## Python Package
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `src/traccia/__init__.py` | 5 | Package version surface. |
+| `src/traccia/__main__.py` | 4 | `python -m traccia` entrypoint. |
+| `src/traccia/bootstrap.py` | 414 | Project scaffold, prompts, initial artifacts, and SQLite schema. |
+| `src/traccia/cli.py` | 930 | Typer CLI command surface. |
+| `src/traccia/config.py` | 163 | Config schema and YAML load/write helpers. |
+| `src/traccia/curation.py` | 595 | Viewer curation and public graph redaction. |
+| `src/traccia/document_normalizer.py` | 296 | PDF/DOCX normalization provider chain. |
+| `src/traccia/extraction.py` | 204 | Evidence extraction contracts. |
+| `src/traccia/family_normalizer.py` | 1187 | Source-family normalization. |
+| `src/traccia/fixtures.py` | 44 | Test fixture helpers. |
+| `src/traccia/google_takeout.py` | 193 | Google Takeout relevance policy. |
+| `src/traccia/llm.py` | 1342 | Backend abstraction, structured calls, retries, and leases. |
+| `src/traccia/models.py` | 317 | Strict domain models and enums. |
+| `src/traccia/parsers.py` | 1630 | Parser registry, spans, attachments, and chunking. |
+| `src/traccia/pipeline.py` | 4368 | End-to-end discovery, ingest, scoring, resume, and graph sync. |
+| `src/traccia/pipeline_support.py` | 163 | Support scoring and skill-state helpers. |
+| `src/traccia/rendering.py` | 1069 | Graph, markdown, profile, Obsidian, and debug rendering. |
+| `src/traccia/source_detection.py` | 291 | Source type and family detection. |
+| `src/traccia/storage.py` | 851 | SQLite persistence, queries, review, overrides, and caches. |
+| `src/traccia/taxonomy.py` | 119 | Built-in taxonomy seeds and aliases. |
+| `src/traccia/utils.py` | 45 | IDs, slugs, timestamps, hashes, and text helpers. |
+| `src/traccia/viewer.py` | 924 | Static viewer export, admin export, and publish assembly. |
+| `src/traccia/viewer_assets.py` | 10555 | Embedded viewer HTML, CSS, JavaScript, and SFX assets. |
+
+## Assets
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `src/traccia/assets/favicon.svg` | 14 | Viewer and package favicon. |
+| `src/traccia/assets/fonts/README.md` | 10 | Font asset notes. |
+| `src/traccia/assets/fonts/traccia-display-bold.ttf` | 1355 | Bundled display font. |
+| `src/traccia/assets/fonts/traccia-display-medium.ttf` | 1298 | Bundled display font. |
+| `src/traccia/assets/fonts/traccia-display-regular.ttf` | 875 | Bundled display font. |
+| `src/traccia/assets/fonts/traccia-label-bold.ttf` | 1172 | Bundled label font. |
+| `src/traccia/assets/fonts/traccia-label-medium.ttf` | 897 | Bundled label font. |
+| `src/traccia/assets/fonts/traccia-label-regular.ttf` | 2341 | Bundled label font. |
+| `src/traccia/assets/fonts/traccia-mono-bold.ttf` | 1354 | Bundled mono font. |
+| `src/traccia/assets/fonts/traccia-mono-medium.ttf` | 1209 | Bundled mono font. |
+| `src/traccia/assets/fonts/traccia-mono-regular.ttf` | 1012 | Bundled mono font. |
+| `src/traccia/assets/fonts/traccia-ui-bold.ttf` | 1190 | Bundled UI font. |
+| `src/traccia/assets/fonts/traccia-ui-medium.ttf` | 1517 | Bundled UI font. |
+| `src/traccia/assets/fonts/traccia-ui-regular.ttf` | 1413 | Bundled UI font. |
+
+## npm And Scripts
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `npm/bin/traccia.js` | 56 | Node launcher that delegates to `uvx` or local `uv run`. |
+| `scripts/check-viewer-performance.mjs` | 1250 | Maintainer browser performance check for viewer exports. |
+
+## Test Fixtures
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `tests/fixtures/corpus/app.py` | 10 | Small code fixture. |
+| `tests/fixtures/corpus/notes.md` | 5 | Small notes fixture. |
+| `tests/fixtures/corpus/project-readme.md` | 4 | Small README fixture. |
+| `tests/fixtures/corpus/tasks.csv` | 2 | Small CSV fixture. |
+| `tests/fixtures/golden/evidence-item.json` | 21 | Evidence model golden fixture. |
+| `tests/fixtures/golden/manifest.json` | 8 | Manifest golden fixture. |
+| `tests/fixtures/golden/person-skill-state.json` | 25 | Skill-state golden fixture. |
+| `tests/fixtures/golden/project/config.yaml` | 29 | Golden project config. |
+| `tests/fixtures/golden/sample-source.md` | 3 | Golden source fixture. |
+| `tests/fixtures/golden/skill-node.json` | 15 | Skill-node golden fixture. |
+| `tests/fixtures/golden/source-document.json` | 17 | Source-document golden fixture. |
+
+## Tests
+
+| File | Lines | Documentation role |
+| --- | ---: | --- |
+| `tests/test_config.py` | 75 | Config defaults and validation contracts. |
+| `tests/test_error_messages.py` | 50 | User-facing error message contracts. |
+| `tests/test_extraction.py` | 167 | Evidence extraction and attribution contracts. |
+| `tests/test_fixtures.py` | 12 | Fixture loading contract. |
+| `tests/test_init.py` | 910 | Project scaffold and doctor contracts. |
+| `tests/test_llm.py` | 945 | Backend, structured output, retry, and lease contracts. |
+| `tests/test_models.py` | 32 | Domain model validation contracts. |
+| `tests/test_npm_wrapper.py` | 109 | npm launcher contracts. |
+| `tests/test_parsers.py` | 1060 | Parser, attachment, and normalization contracts. |
+| `tests/test_pipeline.py` | 3506 | Ingest, scoring, staging, deletion, resume, and export contracts. |
+| `tests/test_signal_handling.py` | 286 | Interruption and signal handling contracts. |
+| `tests/test_source_detection.py` | 98 | Source type and family detection contracts. |
+| `tests/test_storage.py` | 58 | SQLite storage contracts. |
+| `tests/test_utils.py` | 29 | Utility helper contracts. |
+| `tests/test_viewer.py` | 3659 | Viewer, admin curation, publish, accessibility, performance, and redaction contracts. |

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2035,7 +2035,7 @@ def test_ingest_dir_cli_rejects_invalid_parallel_extractions(tmp_path: Path) -> 
     )
 
     assert result.exit_code != 0
-    assert "parallel-extractions" in result.output
+    assert "1<=x<=16" in result.output
 
 
 def test_ingest_dir_parallel_extractions_preserve_results(tmp_path: Path) -> None:


### PR DESCRIPTION
**Summary**

- Shortens the README into a product overview, quick start, install paths, and docs entry point.
- Adds user-facing documentation for quickstart, CLI, project layout, configuration, ingestion, exports, architecture, development, and repository inventory.
- Corrects stale docs claims around `graph_scoring.parallel_scores` and public viewer search behavior.
- Adjusts a CLI validation test to assert the stable numeric bound text that CI renders across Python/Typer environments.

**Validation**

- `uv run pytest -q` passed locally before PR creation: 361 tests.
- `uv run pytest tests/test_pipeline.py::test_ingest_dir_cli_rejects_invalid_parallel_extractions -q` passed after the CI assertion fix.
- Checked README/docs for forbidden fancy Unicode.
- Verified current CLI surface with `uv run traccia --help` and `uv run traccia export --help`.